### PR TITLE
Create Infrastructure for Mastodon Instance

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: hashicorp/setup-terraform@v1
       with: 
-        terraform_version: "1.2.8"
+        terraform_version: "1.3.4"
         terraform_wrapper: false
     - name: "Configure AWS Credentials"
       uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,120 @@
+name: "Deploy"
+
+on:
+  pull_request:
+    branches:
+    - main
+  push:
+    branches:
+    - main
+
+jobs: 
+  terraform-production:
+    name: "Terraform"
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+      security-events: write
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: './terraform/production'
+    steps:
+    - uses: actions/checkout@v2
+    - uses: hashicorp/setup-terraform@v1
+      with: 
+        terraform_version: "1.2.8"
+        terraform_wrapper: false
+    - name: "Configure AWS Credentials"
+      uses: aws-actions/configure-aws-credentials@v1
+      with: 
+        aws-region: us-west-2
+        role-to-assume: "arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github"
+    - run: aws sts get-caller-identity
+
+    - name: Terraform fmt
+      id: fmt
+      run: terraform fmt -check
+
+    - name: Terraform Init
+      id: init
+      run: terraform init
+
+    - name: Terraform Validate
+      id: validate
+      run: terraform validate -no-color
+
+    - name: Terraform Plan
+      id: plan
+      if: github.event_name == 'pull_request'
+      run: terraform plan -no-color
+
+    - uses: actions/github-script@0.9.0
+      if: github.ref != 'refs/heads/main' && github.event_name == 'pull_request' && steps.plan.outputs.stdout != 'null'
+      env:
+        PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const validate = ${{ toJson(steps.validate.outputs.stdout) }};
+          const plan = ${{ toJson(steps.plan.outputs.stdout) }};
+
+          const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
+          #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
+          #### Terraform Validation 🤖\`${{ steps.validate.outcome }}\`
+          #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
+
+          <details><summary>Show Plan</summary>
+
+          \`\`\`terraform\n${plan}\`\`\`
+
+          </details>
+          
+          *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`, Working Directory: \`${{ env.tf_actions_working_dir }}\`, Workflow: \`${{ github.workflow }}\`*`;
+            
+          github.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: output
+          })
+
+    - name: Terraform Plan Status
+      if: steps.plan.outcome == 'failure' || steps.fmt.outcome == 'failure'
+      run: exit 1
+
+#    - name: Run tfsec
+#      uses: tfsec/tfsec-sarif-action@9a83b5c3524f825c020e356335855741fd02745f
+#      with:
+#        sarif_file: tfsec.sarif         
+#
+#    - name: Upload SARIF file
+#      uses: github/codeql-action/upload-sarif@v1
+#      with:
+#        # Path to SARIF file relative to the root of the repository
+#        sarif_file: tfsec.sarif  
+
+    - name: Terraform Apply
+      if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+      run: terraform apply -auto-approve
+  deploy:
+    name: "Deploy Mastodon Server"
+    permissions:
+      contents: read
+      id-token: write
+    needs: terraform-production
+    if: github.ref == 'refs/heads/main' 
+    defaults:
+      run: 
+        working-directory: "."
+    runs-on: ubuntu-latest
+    steps: 
+      - 
+        uses: actions/checkout@v2
+      - 
+        name: "Configure AWS Credentials"
+        uses: aws-actions/configure-aws-credentials@v1
+        with: 
+          aws-region: us-west-2
+          role-to-assume: "arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github"

--- a/terraform/production/backend.tf
+++ b/terraform/production/backend.tf
@@ -1,0 +1,18 @@
+terraform {
+  backend "s3" {
+    bucket = "rhill-terraform"
+    key    = "rah.social/terraform.tfstate"
+    region = "us-west-2"
+  }
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+  required_version = "1.3.4"
+}
+
+provider "aws" {
+  region = "us-west-2"
+}

--- a/terraform/production/data.tf
+++ b/terraform/production/data.tf
@@ -1,0 +1,26 @@
+# Latest Ubuntu AMI
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"] # Canonical
+}
+
+
+# Route53 Zone
+
+data "aws_route53_zone" "this" {
+  name = "rah.social"
+}
+
+

--- a/terraform/production/ec2.tf
+++ b/terraform/production/ec2.tf
@@ -9,7 +9,7 @@ module "ec2_instance" {
   key_name               = "console"
   monitoring             = true
   vpc_security_group_ids = module.vpc.default_security_group_id
-  subnet_id              = module.vpc.public_subnets[1]
+  subnet_id              = element(module.vpc.private_subnets, 0)
 
   tags = local.tags
 }

--- a/terraform/production/ec2.tf
+++ b/terraform/production/ec2.tf
@@ -9,7 +9,7 @@ module "ec2_instance" {
   key_name               = "console"
   monitoring             = true
   vpc_security_group_ids = module.vpc.default_security_group_id
-  subnet_id              = module.vpc.subnet_id
+  subnet_id              = module.vpc.public_subnets[1]
 
   tags = local.tags
 }

--- a/terraform/production/ec2.tf
+++ b/terraform/production/ec2.tf
@@ -1,0 +1,20 @@
+module "ec2_instance" {
+  source  = "terraform-aws-modules/ec2-instance/aws"
+  version = "~> 3.0"
+
+  name = "mastodon-server-production"
+
+  ami                    = "ami-ebd02392"
+  instance_type          = "t2.micro"
+  key_name               = "user1"
+  monitoring             = true
+  vpc_security_group_ids = ["sg-12345678"]
+  subnet_id              = "subnet-eddcdzz4"
+
+  tags = {
+    Terraform   = "true"
+    Environment = "production"
+    Site        = "rah.social"
+  }
+}
+

--- a/terraform/production/ec2.tf
+++ b/terraform/production/ec2.tf
@@ -4,16 +4,12 @@ module "ec2_instance" {
 
   name = local.name
 
-  ami                    = "ami-ebd02392"
-  instance_type          = "t3a.micro"
-  key_name               = "user1"
+  ami                    = data.aws_ami.ubuntu.id
+  instance_type          = local.instance_type
+  key_name               = "console"
   monitoring             = true
-  vpc_security_group_ids = ["sg-12345678"]
-  subnet_id              = "subnet-eddcdzz4"
+  vpc_security_group_ids = module.vpc.default_security_group_id
+  subnet_id              = module.vpc.subnet_id
 
-  tags = {
-    Terraform   = "true"
-    Environment = "production"
-    Site        = "rah.social"
-  }
+  tags = local.tags
 }

--- a/terraform/production/ec2.tf
+++ b/terraform/production/ec2.tf
@@ -1,6 +1,6 @@
 module "ec2_instance" {
   source  = "terraform-aws-modules/ec2-instance/aws"
-  version = "~> 4.2.0"
+  version = "~> 3.0"
 
   name = local.name
 

--- a/terraform/production/ec2.tf
+++ b/terraform/production/ec2.tf
@@ -1,11 +1,11 @@
 module "ec2_instance" {
   source  = "terraform-aws-modules/ec2-instance/aws"
-  version = "~> 3.0"
+  version = "~> 4.2.0"
 
-  name = "mastodon-server-production"
+  name = local.name
 
   ami                    = "ami-ebd02392"
-  instance_type          = "t2.micro"
+  instance_type          = "t3a.micro"
   key_name               = "user1"
   monitoring             = true
   vpc_security_group_ids = ["sg-12345678"]
@@ -17,4 +17,3 @@ module "ec2_instance" {
     Site        = "rah.social"
   }
 }
-

--- a/terraform/production/locals.tf
+++ b/terraform/production/locals.tf
@@ -1,6 +1,7 @@
 locals {
-  name   = "mastodon-server-production"
-  region = "us-west-2"
+  name          = "mastodon-server-production"
+  region        = "us-west-2"
+  instance_type = "t3a.micro"
 
   tags = {
     Terraform   = "true"

--- a/terraform/production/locals.tf
+++ b/terraform/production/locals.tf
@@ -1,0 +1,10 @@
+locals {
+  name   = "mastodon-server-production"
+  region = "us-west-2"
+
+  tags = {
+    Terraform   = "true"
+    Environment = "production"
+    Site        = "rah.social"
+  }
+}

--- a/terraform/production/route53.tf
+++ b/terraform/production/route53.tf
@@ -1,0 +1,3 @@
+data "aws_route53_zone" "this" {
+  name = "rah.social"
+}

--- a/terraform/production/route53.tf
+++ b/terraform/production/route53.tf
@@ -1,3 +1,0 @@
-data "aws_route53_zone" "this" {
-  name = "rah.social"
-}

--- a/terraform/production/vpc.tf
+++ b/terraform/production/vpc.tf
@@ -1,0 +1,14 @@
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 3.0"
+
+  name = local.name
+  cidr = "10.99.0.0/18"
+
+  azs              = ["${local.region}a", "${local.region}b", "${local.region}c"]
+  public_subnets   = ["10.99.0.0/24", "10.99.1.0/24", "10.99.2.0/24"]
+  private_subnets  = ["10.99.3.0/24", "10.99.4.0/24", "10.99.5.0/24"]
+  database_subnets = ["10.99.7.0/24", "10.99.8.0/24", "10.99.9.0/24"]
+
+  tags = local.tags
+}

--- a/terraform/production/vpc.tf
+++ b/terraform/production/vpc.tf
@@ -3,7 +3,12 @@ module "vpc" {
   version = "~> 3.0"
 
   name = local.name
+
+  enable_nat_gateway = true
+  single_nat_gateway = true
+
   cidr = "10.99.0.0/18"
+
 
   azs              = ["${local.region}a", "${local.region}b", "${local.region}c"]
   public_subnets   = ["10.99.0.0/24", "10.99.1.0/24", "10.99.2.0/24"]


### PR DESCRIPTION
In order to be a good community steward and to (selfishly) get my own custom domain name for Mastodon, I am creating my own private instance. This should hopefully reduce strain on the major community instances, give me more control over my instance behavior, and allow me to practice distribution and federation of something like Mastodon.